### PR TITLE
Regex performance bottlenecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- _Nothing yet._
+- Optional regex profiling mode gated by `Options::regex_profiling`, including CLI reporting of total regex time, match counts, and the heaviest rules when enabled.
+- `--regex-profile` CLI flag to toggle profiling without code changes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- _Nothing yet._
+
+### Changed
+
+- _Nothing yet._
+
+### Fixed
+
+- _Nothing yet._
+
+## [0.4.2] - 2026-02-02
+
+### Added
+
 - Optional regex profiling mode gated by `Options::regex_profiling`, including CLI reporting of total regex time, match counts, and the heaviest rules when enabled.
 - `--regex-profile` CLI flag to toggle profiling without code changes.
 
@@ -26,5 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release after development. This is the first public release of astorion.
 
-[Unreleased]: https://github.com/john-wennstrom/astorion/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/john-wennstrom/astorion/releases/tag/v0.4.0
+[Unreleased]: https://github.com/john-wennstrom/astorion/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/john-wennstrom/astorion/releases/tag/v0.4.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "astorion"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bitflags",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "astorion"
 readme = "README.md"
 repository = "https://github.com/john-wennstrom/astorion"
 rust-version = "1.85.0"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 bitflags = "2.4"

--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ cargo run -- --help
 | `--reference <timestamp>` | Reference time in `YYYY-MM-DDTHH:MM:SS` (default: `2013-02-12T04:30:00`).                          |
 | `--color`                 | Force ANSI color output.                                                                           |
 | `--no-color`              | Disable ANSI color output.                                                                         |
+| `--regex-profile`         | Collect regex timing stats and print a profiling summary (adds overhead). See `docs/regex-profiling.md` for guidance. |
 | `-h, --help`              | Show help text.                                                                                    |
 | `-V, --version`           | Print version information.                                                                         |
 
-Set `RUSTLING_DEBUG_RULES=1` to print rule filtering/production diagnostics.
+Set `RUSTLING_DEBUG_RULES=1` to print rule filtering/production diagnostics. Detailed tips for interpreting the regex profiling report live in `docs/regex-profiling.md`.
 
 ## How it works
 

--- a/docs/regex-profiling.md
+++ b/docs/regex-profiling.md
@@ -1,0 +1,39 @@
+# Regex Profiling Guide
+
+Astorion can help you spot slow or overly chatty regexes while parsing. Just run the CLI with the`--regex-profile` flag:
+
+```bash
+cargo run -- --regex-profile --input "on friday at 5"
+```
+
+When profiling is enabled, the CLI report includes an extra section that breaks down regex activity:
+
+```
+━━━ Regex Profiling ━━━
+  Total regex time: 13.706386ms  │  Matches: 488
+  from <time-of-day> - <time-of-day> on <weekday> 339.141µs  evals: 18  matches: 60
+  <weekday> 265.942µs  evals: 4  matches: 4
+  <weekday> <time-of-day> 238.549µs  evals: 4  matches: 0
+  this|last|next qtr 235.802µs  evals: 4  matches: 0
+  <time>'s <weekday> 216.708µs  evals: 44  matches: 22
+```
+
+## How to read the summary
+
+- **Total regex time** — The total wall-clock time spent evaluating regexes during this run. Compare this with the overall saturation time to see whether regexes are a major contributor to parsing cost.
+- **Matches** — The total number of capture hits across all regexes. A high match count with low total time usually means cheap literal matches. Fewer matches with high time, on the other hand, often point to expensive or overly broad rules.
+- **Per-rule rows** contain:
+  - `rule name`
+  - `total_time` — how much time was spent running regexes for this rule
+  - `evals` — how many times those regexes were evaluated
+  - `matches` — how many capture hits they produced
+
+## Using the data to optimize
+
+1. **Target the heaviest rules first.** Rules at the top of the list cost the most time overall. Simplifying their regexes or reducing how often they run usually gives the biggest payoff.
+2. **Watch for noisy rules that never match.** A high evals count with matches: 0 means the rule scans the input frequently but never contributes anything. Tighten its triggers or replace broad patterns with more specific ones.
+3. **Check match density.** If `matches` is large but `total_time` is also large, consider breaking the regex into smaller pieces, pre-filtering the input, or caching intermediate results.
+4. **Compare against saturation time.** When `Total regex time` is close to the overall saturation time, regex evaluation is your bottleneck. Predicate-first rules, pre-tokenization, or better triggers can help avoid full input scans.
+5. **Re-measure after changes.** Re-run `cargo run -- --regex-profile ...` after refactors to confirm the targeted rules dropped in the ranking and the total regex time decreased.
+
+The profiler is intentionally opt-in so normal runs stay fast. Use it on representative inputs before and after changes to make sure your optimizations actually improve real-world workloads.

--- a/src/debug_report.rs
+++ b/src/debug_report.rs
@@ -42,6 +42,11 @@ pub fn print_run(input: &str, details: &ParseDetails, color: bool) {
     println!("\n{}", palette.paint("━━━ Saturation ━━━", ansi::GRAY));
     print_saturation(details, &palette);
 
+    if details.regex_profile.is_some() {
+        println!("\n{}", palette.paint("━━━ Regex Profiling ━━━", ansi::GRAY));
+        print_regex_profile(details, &palette);
+    }
+
     // Results
     println!("\n{}", palette.paint("━━━ Results ━━━", ansi::GRAY));
     if details.all_candidates.is_empty() {
@@ -105,6 +110,35 @@ fn print_results(details: &ParseDetails, palette: &ansi::Palette) {
             palette.paint(&ent.name, ansi::BLUE),
             palette.dim("│ rule:"),
             palette.paint(&ent.rule, ansi::CYAN)
+        );
+    }
+}
+
+fn print_regex_profile(details: &ParseDetails, palette: &ansi::Palette) {
+    let Some(profile) = &details.regex_profile else {
+        return;
+    };
+
+    println!(
+        "  Total regex time: {}  │  Matches: {}",
+        palette.paint(format!("{:?}", profile.total_time), ansi::GREEN),
+        palette.paint(profile.total_matches.to_string(), ansi::BLUE)
+    );
+
+    if profile.rules.is_empty() {
+        println!("  {}", palette.dim("No regex rules executed"));
+        return;
+    }
+
+    for rule in &profile.rules {
+        println!(
+            "  {} {}  {} {}  {} {}",
+            palette.paint(rule.rule, ansi::CYAN),
+            palette.dim(format!("{:?}", rule.total_time)),
+            palette.dim("evals:"),
+            palette.paint(rule.evaluations.to_string(), ansi::YELLOW),
+            palette.dim("matches:"),
+            palette.paint(rule.matches.to_string(), ansi::YELLOW)
         );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -88,7 +88,7 @@ mod trigger;
 #[allow(unused_imports)]
 pub use compiled_rules::{BucketMask, CompiledRules, DimensionSet, RuleIndex, RuleMeta};
 #[allow(unused_imports)]
-pub use metrics::{PassMetrics, RunMetrics, RunResult, SaturationMetrics};
+pub use metrics::{PassMetrics, RegexProfileSummary, RegexRuleProfile, RunMetrics, RunResult, SaturationMetrics};
 #[allow(unused_imports)]
 pub use parser::Parser;
 #[allow(unused_imports)]

--- a/src/engine/metrics.rs
+++ b/src/engine/metrics.rs
@@ -33,6 +33,8 @@ pub struct RunMetrics {
     pub saturation: SaturationMetrics,
     /// Time spent resolving tokens after saturation.
     pub resolve: Duration,
+    /// Regex profiling summary collected when profiling is enabled.
+    pub regex_profile: Option<RegexProfileSummary>,
 }
 
 /// Timings for the saturation phase.
@@ -61,6 +63,30 @@ pub struct PassMetrics {
     pub _rules_seeded: usize,
     /// Number of regex first-pattern hits across all rules.
     pub _regex_first_pattern_hits: usize,
+}
+
+/// Aggregated regex profiling details for the most expensive rules.
+#[derive(Debug, Clone, Default)]
+pub struct RegexProfileSummary {
+    /// Total wall-clock time spent evaluating regex patterns.
+    pub total_time: Duration,
+    /// Total number of matches observed across all regex evaluations.
+    pub total_matches: u64,
+    /// Per-rule breakdown (sorted by descending total_time).
+    pub rules: Vec<RegexRuleProfile>,
+}
+
+/// Regex profiling stats for a single rule.
+#[derive(Debug, Clone)]
+pub struct RegexRuleProfile {
+    /// Name of the rule.
+    pub rule: &'static str,
+    /// Number of times regex patterns within this rule were evaluated.
+    pub evaluations: u64,
+    /// Total number of matches produced by those evaluations.
+    pub matches: u64,
+    /// Cumulative time spent evaluating regex patterns for this rule.
+    pub total_time: Duration,
 }
 
 /// Parser output bundled with timing information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ mod rules;
 mod time_expr;
 
 pub use api::{
-    Context, Entity, NodeSummary, Options, ParseDetails, ParseResult, parse, parse_verbose_with, parse_with,
+    Context, Entity, NodeSummary, Options, ParseDetails, ParseResult, RegexProfilingOptions, parse,
+    parse_verbose_with, parse_with,
 };
 
 use crate::time_expr::TimeExpr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ mod rules;
 mod time_expr;
 
 pub use api::{
-    Context, Entity, NodeSummary, Options, ParseDetails, ParseResult, RegexProfilingOptions, parse,
-    parse_verbose_with, parse_with,
+    Context, Entity, NodeSummary, Options, ParseDetails, ParseResult, RegexProfilingOptions, parse, parse_verbose_with,
+    parse_with,
 };
 
 use crate::time_expr::TimeExpr;

--- a/src/rules/numeral/tests.rs
+++ b/src/rules/numeral/tests.rs
@@ -117,7 +117,7 @@ fn numeral_examples_matching() {
 
     for (expected, input) in cases {
         let ctx = Context::default();
-        let opts = Options {};
+        let opts = Options::default();
 
         // Run the full parser (like `main.rs`) so composite rules can fire.
         let parser = crate::engine::Parser::new(input, &rules);

--- a/src/rules/time/tests.rs
+++ b/src/rules/time/tests.rs
@@ -863,7 +863,7 @@ fn time_examples_matching() {
     let ctx = reference_context();
 
     for (expected, input) in cases {
-        let opts = Options {};
+        let opts = Options::default();
 
         let parser = crate::engine::Parser::new(input, &rules);
         let resolved = parser.run(&ctx, &opts);


### PR DESCRIPTION
## What changed / why

- Optional regex profiling mode gated by `Options::regex_profiling`, including CLI reporting of total regex time, match counts, and the heaviest rules when enabled.
- `--regex-profile` CLI flag to toggle profiling without code changes.

## How to test

```bash
cargo test
# optionally
RUSTLING_DEBUG_RULES=1 cargo run -- --regex-profile -i "from 2:30 - 5:50"
```

